### PR TITLE
fixing failing rolling_mean in pandas 0.23.3

### DIFF
--- a/oceans/sw_extras/sw_extras.py
+++ b/oceans/sw_extras/sw_extras.py
@@ -859,11 +859,11 @@ def zmld_so(s, t, p, threshold=0.05, smooth=None):
         Research, 38(89):981-1007. doi:10.1016/0198-0149(91)90093-U
 
     """
-    from pandas import rolling_mean
+    from pandas import rolling
     sigma_t = sigmatheta(s, t, p)
     depth = p
     if smooth is not None:
-        sigma_t = rolling_mean(sigma_t, smooth, min_periods=1)
+        sigma_t = rolling(sigma_t, smooth, min_periods=1).mean()
 
     sublayer = np.where(depth[(depth >= 5) & (depth <= 10)])[0]
     sigma_x = np.nanmean(sigma_t[sublayer])


### PR DESCRIPTION
See: https://github.com/pandas-dev/pandas/blob/0.19.x/doc/source/whatsnew/v0.18.0.txt#L66-L68

I can't run the coastal wave heights notebook because I'm getting:
```python-traceback
**************************** Models ****************************

[Reading url 1/1]: http://thredds.secoora.org/thredds/dodsC/SECOORA_NCSU_CNAPS.nc
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-13-37d6170beadb> in <module>()
     19                              time=(config['date']['start'],
     20                                    config['date']['stop']),
---> 21                              units=config['units'])
     22         else:
     23             print('[Not model data]: {}'.format(url))

/opt/conda/lib/python3.6/site-packages/ioos_tools/tardis.py in proc_cube(cube, bbox, time, constraint, units)
    470             raise ValueError('No cube using {!r}'.format(constraint))
    471     if bbox:
--> 472         cube = subset(cube, bbox)
    473         if not cube:
    474             raise ValueError('No cube using {!r}'.format(bbox))

/opt/conda/lib/python3.6/site-packages/ioos_tools/tardis.py in subset(cube, bbox)
    387     elif (cube.coord(axis='X').ndim == 2 and
    388           cube.coord(axis='Y').ndim == 2):
--> 389         cube = bbox_extract_2Dcoords(cube, bbox)
    390     else:
    391         msg = "Cannot deal with X:{!r} and Y:{!r} dimensions."

/opt/conda/lib/python3.6/site-packages/ioos_tools/tardis.py in bbox_extract_2Dcoords(cube, bbox)
    333 
    334     """
--> 335     imin, imax, jmin, jmax = _get_indices(cube, bbox)
    336     return cube[..., imin:imax, jmin:jmax]
    337 

/opt/conda/lib/python3.6/site-packages/ioos_tools/tardis.py in _get_indices(cube, bbox)
    299 
    300     """
--> 301     from oceans import wrap_lon180
    302     lons = cube.coord('longitude').points
    303     lats = cube.coord('latitude').points

/opt/conda/lib/python3.6/site-packages/oceans/__init__.py in <module>()
     15 from .plotting import *
     16 from .colormaps import *
---> 17 from .sw_extras import *

/opt/conda/lib/python3.6/site-packages/oceans/sw_extras/__init__.py in <module>()
----> 1 from .sw_extras import *
      2 from .waves import Waves
      3 from .gamma_GP_from_SP_pt import gamma_GP_from_SP_pt

/opt/conda/lib/python3.6/site-packages/oceans/sw_extras/sw_extras.py in <module>()
     12 import numpy as np
     13 import seawater as sw
---> 14 from pandas import rolling_mean
     15 from seawater.constants import OMEGA, earth_radius
     16 

ImportError: cannot import name 'rolling_mean'
```